### PR TITLE
Testing 0.3.8~ynh3 / Improve systemd hardening

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -41,6 +41,10 @@ echo "PROCEED=false" >> "$GITHUB_ENV"
 if ! dpkg --compare-versions "$current_version" "lt" "$version" ; then
     echo "::warning ::No new version available"
     exit 0
+# Proceed only if the retrieved version is not a release candidate
+elif [[ "$version" == *"rc"* ]] ; then
+    echo "::warning ::No new version available"
+    exit 0
 # Proceed only if a PR for this new version does not already exist
 elif git ls-remote -q --exit-code --heads https://github.com/"$GITHUB_REPOSITORY".git ci-auto-update-v"$version" ; then
     echo "::warning ::A branch already exists for this update"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ With GoToSocial, you can keep in touch with your friends, post, read, and share 
 Documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).
 
 
-**Shipped version:** 0.3.8~ynh2
+**Shipped version:** 0.3.8~ynh3
 
 
 ## Screenshots

--- a/README_fr.md
+++ b/README_fr.md
@@ -24,7 +24,7 @@ Avec GoToSocial, vous pouvez rester en contact avec vos amis, publier, lire et p
 Vous pouvez consulter la documentation à l'adresse : [docs.gotosocial.org](https://docs.gotosocial.org).
 
 
-**Version incluse :** 0.3.8~ynh2
+**Version incluse :** 0.3.8~ynh3
 
 
 ## Captures d'écran

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -20,16 +20,20 @@ StandardError=inherit
 NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateDevices=yes
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 RestrictNamespaces=yes
 RestrictRealtime=yes
 DevicePolicy=closed
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
 ProtectSystem=full
 ProtectControlGroups=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes
 LockPersonality=yes
-SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap @cpu-emulation @privileged
 
 # Denying access to capabilities that should not be relevant for webapps
 # Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
         "userdoc": "https://docs.gotosocial.org/en/latest/",
         "code": "https://github.com/superseriousbusiness/gotosocial"
     },
-    "license": "WTFPL",
+    "license": "AGPL-3.0-only",
     "maintainer": {
         "name": "OniriCorpe",
         "email": ""

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "An ActivityPub social network server, written in Golang.",
         "fr": "Un serveur de réseau social basé sur ActivityPub écrit en Golang."
     },
-    "version": "0.3.8~ynh2",
+    "version": "0.3.8~ynh3",
     "url": "https://github.com/superseriousbusiness/gotosocial",
     "upstream": {
         "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Problem

- https://github.com/YunoHost/example_ynh/pull/180

## Solution

- Apply it (except for `ProtectKernelLogs=yes` wich is not available for now on ynh stable (`yunohost 11.0.9.5` `systemd 247.3-7`))

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)