### PR TITLE
Fix typo in [main.instance.instance_expose_suspended_web]

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -248,7 +248,7 @@ type = "select"
 [main.instance.instance_expose_suspended_web]
 ask.en = "API: Expose suspended on Web (/about/suspended)?"
 ask.fr = "API : Exposer les instances bloquées sur le Web (/about/suspended) ?"
-bind = "instance-expose-suspended_web:__FINALPATH__/config.yaml"
+bind = "instance-expose-suspended-web:__FINALPATH__/config.yaml"
 choices = ["true", "false"]
 default = "false"
 help.en = "Allow unauthenticated users to view /about/suspended, showing the HTML rendered list of instances that this instance blocks/suspends."


### PR DESCRIPTION
Fix `Config panel question 'instance_expose_suspended_web' should be initialized with a value during install or upgrade.` error.

## Problem

Encounter an error when accessing gotosocial config in the admin panel

## Solution

changing `_` in [config_panel.toml#L251](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/testing/config_panel.toml#L251)
```
bind = "instance-expose-suspended_web:__FINALPATH__/config.yaml"
```
to a `-` fixed the issue

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

(manually making changes on the live system fixed the issue)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
<img width="777" alt="Screen Shot 2023-02-21 at 3 26 44 PM" src="https://user-images.githubusercontent.com/1066985/220464221-6c9b67a8-2d8d-4feb-9f26-4b0aba66b1bd.png">
