### PR TITLE
Add SMTP CONFIG options to Config Panel

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -702,30 +702,30 @@ oidc-admin-groups: []
 # If this is not set, smtp will not be used to send emails, and you can ignore the other settings.
 # Examples: ["mail.example.org", "localhost"]
 # Default: ""
-smtp-host: "localhost"
+smtp-host: "__SMTP_HOST__"
 
 # Int. Port to use to connect to the smtp server.
 # Examples: []
 # Default: 0
-smtp-port: 25
+smtp-port: __SMTP_PORT__
 
 # String. Username to use when authenticating with the smtp server.
 # This should have been provided to you by your smtp host.
 # This is often, but not always, an email address.
 # Examples: ["maillord@example.org"]
 # Default: ""
-smtp-username: ""
+smtp-username: "__SMTP_USERNAME__"
 
 # String. Password to use when authenticating with the smtp server.
 # This should have been provided to you by your smtp host.
 # Examples: ["1234", "password"]
 # Default: ""
-smtp-password: ""
+smtp-password: "__SMTP_PASSWORD__"
 
 # String. 'From' address for sent emails.
 # Examples: ["mail@example.org"]
 # Default: ""
-smtp-from: "GoToSocial@__DOMAIN__"
+smtp-from: "__SMTP_FROM__"
 
 # Bool. If true, when an email is sent that has multiple recipients, each recipient
 # will be included in the To field, so that each recipient can see who else got the
@@ -737,7 +737,7 @@ smtp-from: "GoToSocial@__DOMAIN__"
 # It might be useful to change this setting to 'true' if you want to be able to discuss
 # new moderation reports with other admins by 'replying-all' to the notification email.
 # Default: false
-smtp-disclose-recipients: false
+smtp-disclose-recipients: __SMTP_DISCLOSE_RECIPIENTS__
 
 #########################
 ##### SYSLOG CONFIG #####

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -279,6 +279,73 @@ La livraison dans la boîte de réception partagée peut réduire de manière si
 Voir : https://www.w3.org/TR/activitypub/#shared-inbox-delivery"""
 type = "select"
 
+################
+#### SMTP CONFIG
+################
+
+[main.smtp]
+
+name = "SMTP config"
+
+help = "Config for sending emails via an smtp server."
+
+[main.smtp.smtp_host]
+ask.en = "SMTP Server Hostname"
+ask.fr = "Nom d'hôte du serveur SMTP"
+bind = "smtp-host:__FINALPATH__/config.yaml"
+default = "localhost"
+help.en = "The hostname of the smtp server you want to use. Examples: mail.example.org, localhost"
+help.fr = "Le nom d'hôte du serveur smtp que vous souhaitez utiliser. Exemples: mail.example.org, localhost"
+type = "string"
+
+[main.smtp.smtp_port]
+ask.en = "SMTP Port"
+ask.fr = "Port SMTP"
+bind = "smtp-port:__FINALPATH__/config.yaml"
+default = "25"
+help.en = "Port to use to connect to the smtp server"
+help.fr = "Port à utiliser pour se connecter au serveur smtp"
+type = "number"
+
+[main.smtp.smtp_username]
+ask.en = "SMTP Username"
+ask.fr = "Nom d'utilisateur SMTP"
+bind = "smtp-username:__FINALPATH__/config.yaml"
+default = ""
+help.en = "Username to use when authenticating with the smtp server"
+help.fr = "Nom d'utilisateur à utiliser lors de l'authentification avec le serveur smtp"
+type = "string"
+
+[main.smtp.smtp_password]
+ask.en = "SMTP Password"
+ask.fr = "Mot de passe SMTP"
+bind = "smtp-password:__FINALPATH__/config.yaml"
+default = ""
+help.en = "Password to use when authenticating with the smtp server"
+help.fr = "Mot de passe à utiliser lors de l'authentification avec le serveur smtp"
+type = "password"
+
+[main.smtp.smtp_from]
+ask.en = "SMTP From Address"
+ask.fr = "Adresse d'expédition SMTP"
+bind = "smtp-from:__FINALPATH__/config.yaml"
+default = "GoToSocial@__DOMAIN__"
+help.en = "From address for sent emails"
+help.fr = "De l'adresse pour les e-mails envoyés"
+type = "email"
+
+[main.smtp.smtp_disclose_recipients]
+ask.en = "SMTP Disclose Recipients"
+ask.fr = "SMTP Divulguer les destinataires"
+bind = "smtp-disclose-recipients:__FINALPATH__/config.yaml"
+choices = ["true", "false"]
+default = "false"
+help.en = """true: Disclose all recipients in the To field\
+false: Email will be sent to Undisclosed Recipients"""
+help.fr = """vrai : divulguer tous les destinataires dans le champ À\
+false : l'e-mail sera envoyé aux destinataires non divulgués"""
+type = "select"
+
 ####################
 #### ADVANCED SETTINGS
 ####################


### PR DESCRIPTION
## Problem

- Adding SMTP config options to config panel

## Solution

- Made nessarry changes to config_panel.toml and conf/config.yml

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
