### PR TITLE
Fix accounts keys (settings not kept during upgrade)

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -19,7 +19,7 @@ name = "Accounts config"
 
 help = "Config pertaining to creation and maintenance of accounts on the server, as well as defaults for new accounts."
 
-[main.accounts.registration_open]
+[main.accounts.accounts_registration_open]
 ask.en = "Open registrations?"
 ask.fr = "Inscriptions ouvertes ?"
 bind = "accounts-registration-open:__FINALPATH__/config.yaml"
@@ -29,7 +29,7 @@ help.en = "Do we want people to be able to just submit sign up requests, or do w
 help.fr = "Voulez-vous que les gens puissent simplement envoyer des demandes d'inscription, ou voulez-vous qu'iels doivent être invité-e-s ?"
 type = "select"
 
-[main.accounts.approval_required]
+[main.accounts.accounts_approval_required]
 ask.en = "Approval required?"
 ask.fr = "Validation requise ?"
 bind = "accounts-approval-required:__FINALPATH__/config.yaml"
@@ -39,7 +39,7 @@ help.en = "Do sign up requests require approval from an admin/moderator before a
 help.fr = "Les demandes d'inscription doivent-elles être approuvées par un-e administrateur-ice/modérateur-ice avant qu'un compte puisse se connecter/utiliser le serveur ?"
 type = "select"
 
-[main.accounts.reason_required]
+[main.accounts.accounts_reason_required]
 ask.en = "Reason required?"
 ask.fr = "Motif requis ?"
 bind = "accounts-reason-required:__FINALPATH__/config.yaml"
@@ -49,7 +49,7 @@ help.en = "Are sign up requests required to submit a reason for the request (eg.
 help.fr = "Les demandes d'inscription doivent-elles être motivées (par exemple, par une explication de la raison pour laquelle la personne souhaite rejoindre l'instance) ?"
 type = "select"
 
-[main.accounts.allow_custom_css]
+[main.accounts.accounts_allow_custom_css]
 ask.en = "Allow custom CSS?"
 ask.fr = "Autoriser le CSS personnalisé ?"
 bind = "accounts-allow-custom-css:__FINALPATH__/config.yaml"

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "ActivityPub social network server",
         "fr": "Serveur de réseau social basé sur ActivityPub"
     },
-    "version": "0.8.0~ynh2",
+    "version": "0.8.0~ynh3",
     "url": "https://github.com/superseriousbusiness/gotosocial",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -264,6 +264,32 @@ then
 	ynh_app_setting_set --app="$app" --key=smtp_disclose_recipients --value="$smtp_disclose_recipients"
 fi
 
+# Upgrade from <0.8.0~ynh3:
+if ynh_compare_current_package_version --comparison lt --version 0.8.0~ynh3
+then
+    # get settings from problem key
+    allow_custom_css=$(ynh_app_setting_get --app="$app" --key=allow_custom_css)
+    approval_required=$(ynh_app_setting_get --app="$app" --key=approval_required)
+    reason_required=$(ynh_app_setting_get --app="$app" --key=reason_required)
+    registration_open=$(ynh_app_setting_get --app="$app" --key=registration_open)
+    # apply setting to correct key if set on old key
+    if [ -n "$allow_custom_css" ]
+    then
+        ynh_app_setting_set --app="$app" --key=accounts_allow_custom_css --value="allow_custom_css"
+    fi
+    if [ -n "$approval_required" ]
+    then
+        ynh_app_setting_set --app="$app" --key=accounts_approval_required --value="approval_required"
+    fi
+    if [ -n "$reason_required" ]
+    then
+        ynh_app_setting_set --app="$app" --key=accounts_reason_required --value="reason_required"
+    fi
+    if [ -n "$registration_open" ]
+    then
+        ynh_app_setting_set --app="$app" --key=accounts_registration_open --value="registration_open"
+    fi
+
 #=================================================
 # CREATE DEDICATED USER
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -276,18 +276,22 @@ then
     if [ -n "$allow_custom_css" ]
     then
         ynh_app_setting_set --app="$app" --key=accounts_allow_custom_css --value="allow_custom_css"
+	ynh_app_setting_delete --app="$app" --key=allow_custom_css 
     fi
     if [ -n "$approval_required" ]
     then
         ynh_app_setting_set --app="$app" --key=accounts_approval_required --value="approval_required"
+	ynh_app_setting_delete --app="$app" --key=approval_required 
     fi
     if [ -n "$reason_required" ]
     then
         ynh_app_setting_set --app="$app" --key=accounts_reason_required --value="reason_required"
+	ynh_app_setting_delete --app="$app" --key=reason_required 
     fi
     if [ -n "$registration_open" ]
     then
         ynh_app_setting_set --app="$app" --key=accounts_registration_open --value="registration_open"
+	ynh_app_setting_delete --app="$app" --key=registration_open 
     fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -275,22 +275,22 @@ then
     # apply setting to correct key if set on old key
     if [ -n "$allow_custom_css" ]
     then
-        ynh_app_setting_set --app="$app" --key=accounts_allow_custom_css --value="allow_custom_css"
+        ynh_app_setting_set --app="$app" --key=accounts_allow_custom_css --value="$allow_custom_css"
 	ynh_app_setting_delete --app="$app" --key=allow_custom_css 
     fi
     if [ -n "$approval_required" ]
     then
-        ynh_app_setting_set --app="$app" --key=accounts_approval_required --value="approval_required"
+        ynh_app_setting_set --app="$app" --key=accounts_approval_required --value="$approval_required"
 	ynh_app_setting_delete --app="$app" --key=approval_required 
     fi
     if [ -n "$reason_required" ]
     then
-        ynh_app_setting_set --app="$app" --key=accounts_reason_required --value="reason_required"
+        ynh_app_setting_set --app="$app" --key=accounts_reason_required --value="$reason_required"
 	ynh_app_setting_delete --app="$app" --key=reason_required 
     fi
     if [ -n "$registration_open" ]
     then
-        ynh_app_setting_set --app="$app" --key=accounts_registration_open --value="registration_open"
+        ynh_app_setting_set --app="$app" --key=accounts_registration_open --value="$registration_open"
 	ynh_app_setting_delete --app="$app" --key=registration_open 
     fi
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -293,6 +293,7 @@ then
         ynh_app_setting_set --app="$app" --key=accounts_registration_open --value="registration_open"
 	ynh_app_setting_delete --app="$app" --key=registration_open 
     fi
+fi
 
 #=================================================
 # CREATE DEDICATED USER


### PR DESCRIPTION
## Problem

- Accounts config settings not being kept after upgrade.
- `[main.accounts.{key}]` in `config_panel.toml` do not match up with keys used in `install`, `restore`, and `upgrade` scripts.

## Solution

- Change `[main.accounts.{key}]` to `[main.accounts.accounts_{key}]` in `config_panel.toml`.
- Add section to `upgrade` script to apply values from problem key to correct key.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
    - `config_panel.toml` (tested)
    - `upgrade` script (not tested)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
