### PR TITLE
Place the auto-update script on testing branch

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -16,9 +16,6 @@
 # FETCHING LATEST RELEASE AND ITS ASSETS
 #=================================================
 
-# Access the branch 'testing'
-git checkout testing
-
 # Fetching information
 current_version=$(jq -j '.version|split("~")[0]' manifest.json)
 repo=$(jq -j '.upstream.code|split("https://github.com/")[1]' manifest.json)

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: 'testing'
       - name: Run the updater script
         id: run_updater
         run: |


### PR DESCRIPTION
## Problem

- the auto-update script takes the master branch as a reference, instead of the testing branch, causing updates to be made when the testing branch already has them

## Solution

- trying to place the auto-update script on testing branch

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)