### PR TITLE
Testing v0.11.1~ynh4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With GoToSocial, you can keep in touch with your friends, post, read, and share 
 Documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).
 
 
-**Shipped version:** 0.11.1~ynh3
+**Shipped version:** 0.11.1~ynh4
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ Avec GoToSocial, vous pouvez rester en contact avec vos amis, publier, lire et p
 Vous pouvez consulter la documentation à l'adresse : [docs.gotosocial.org](https://docs.gotosocial.org).
 
 
-**Version incluse :** 0.11.1~ynh3
+**Version incluse :** 0.11.1~ynh4
 
 ## Captures d’écran
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,6 +16,11 @@ location __PATH__/ {
   include conf.d/yunohost_panel.conf.inc;
 
 
+  # fix "[warn] could not build optimal proxy_headers_hash error"
+  proxy_headers_hash_max_size 512;
+  proxy_headers_hash_bucket_size 128;
+
+
   # media caching stuff
   # https://docs.gotosocial.org/en/latest/advanced/caching/assets-media/#nginx
   location /assets/ {
@@ -26,7 +31,7 @@ location __PATH__/ {
   }
 
   location /fileserver/ {
-    alias __DATADIR__;
+    alias /home/yunohost.app/__APP__/;
     autoindex off;
     expires 1w;
     add_header Cache-Control "private, immutable";

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -26,15 +26,15 @@ location __PATH__/ {
   location /assets/ {
     alias __FINAL_PATH__/web/assets/;
     autoindex off;
-    expires 5m;
-    add_header Cache-Control "public";
+    # 300 = 5 minutes
+    more_set_headers "Cache-control: public, max-age=300";
   }
 
   location /fileserver/ {
     alias /home/yunohost.app/__APP__/;
     autoindex off;
-    expires 1w;
-    add_header Cache-Control "private, immutable";
+    # 604800 = 1 week
+    more_set_headers "Cache-Control: private, immutable, max-age=604800";
     try_files $uri @fileserver;
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "ActivityPub social network server",
         "fr": "Serveur de réseau social basé sur ActivityPub"
     },
-    "version": "0.11.1~ynh3",
+    "version": "0.11.1~ynh4",
     "url": "https://github.com/superseriousbusiness/gotosocial",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/install
+++ b/scripts/install
@@ -307,9 +307,9 @@ yunohost service add "$app" --description="Gotosocial server" --log="/var/log/$a
 #=================================================
 ynh_script_progression --message="Creating gotosocial admin user..." --weight=1
 
-ynh_exec_warn_less "$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account create --username "$admin" --email "$email" --password "$password"
+"$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account create --username "$admin" --email "$email" --password "$password"
 
-ynh_exec_warn_less "$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account promote --username "$admin"
+"$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account promote --username "$admin"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/install
+++ b/scripts/install
@@ -307,9 +307,12 @@ yunohost service add "$app" --description="Gotosocial server" --log="/var/log/$a
 #=================================================
 ynh_script_progression --message="Creating gotosocial admin user..." --weight=1
 
-ynh_exec_warn_less "$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account create --username "$admin" --email "$email" --password "$password"
+# using "/var/www/$app" instead of "$final_path" as a temporary workaround for this bug:
+# bad_ynh_exec_syntax() false positive: https://github.com/YunoHost/package_linter/issues/123
 
-ynh_exec_warn_less "$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account promote --username "$admin"
+ynh_exec_warn_less /var/www/"$app"/gotosocial --config-path "$final_path/config.yaml" admin account create --username "$admin" --email "$email" --password "$password"
+
+ynh_exec_warn_less /var/www/"$app"/gotosocial --config-path "$final_path/config.yaml" admin account promote --username "$admin"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/install
+++ b/scripts/install
@@ -307,9 +307,9 @@ yunohost service add "$app" --description="Gotosocial server" --log="/var/log/$a
 #=================================================
 ynh_script_progression --message="Creating gotosocial admin user..." --weight=1
 
-"$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account create --username "$admin" --email "$email" --password "$password"
+ynh_exec_warn_less "$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account create --username "$admin" --email "$email" --password "$password"
 
-"$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account promote --username "$admin"
+ynh_exec_warn_less "$final_path"/gotosocial --config-path "$final_path/config.yaml" admin account promote --username "$admin"
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
## Problem

- `WARNING WARN: bun: 2023/09/10 21:20:01 query "remote_url" has [count(*)] args, but no placeholders` (which is not linked to the package) worries some users
- local medias are not cached

## Solution

- mask the `WARNING WARN: bun: 2023/09/10 21:20:01 query "remote_url" has [count(*)] args, but no placeholders` error, coming from GTS https://github.com/YunoHost-Apps/gotosocial_ynh/pull/100/commits/90927e2da1fa44927907ba54986685fc30f96758
- implement caching for local medias in the nginx config #102 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
