### PR TITLE
removing unnecessary touch for fail2ban setup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
         "email": ""
     },
     "requirements": {
-        "yunohost": ">= 11.0.6"
+        "yunohost": ">= 11.2.6"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -307,9 +307,6 @@ ynh_use_logrotate
 #=================================================
 ynh_script_progression --message="Configuring fail2ban..." --weight=1
 
-# Create the logfile, required before configuring fail2ban
-touch "/var/log/${app}/${app}.log"
-
 # Create a dedicated Fail2Ban config
 ynh_add_fail2ban_config --logpath="/var/log/${app}/${app}.log" --failregex="statusCode=401 path=/auth/sign_in clientIP=<HOST> .* msg=\"Unauthorized:" --max_retry=5
 


### PR DESCRIPTION
## Problem

- manually creating the logfile before configuring fail2ban is now unnecessary, as the helper now do it by itself (>= 11.2.6)

## Solution

- removing the `touch` command (for cleaning purposes) and bumping the minimum version requirement
- merge this **in a month or two** (to give people a little time to update before the package update) ((I've already created this PR, otherwise I'll forget all about this thing tomorrow lmao))

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)