### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ The documentation for this YunoHost package [can be read here](./doc/DOCS.md) an
 
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
-
-**Shipped version:** 0.14.0~ynh1
+**Shipped version:** 0.14.1~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -34,8 +34,8 @@ Veuillez noter que ce paquet utilise la ["i'm so tired" software license 1.0](ht
 
 ## :red_circle: Anti-fonctionnalités
 
-- **Logiciel en version alpha** : Le logiciel est au tout début de son développement. Il pourrait contenir des fonctionnalités changeantes ou instables, des bugs, et des failles de sécurité.
-- **Package sous licence libre restreinte** : Le package YunoHost de cette application est sous une licence globalement libre, mais avec des clauses qui pourraient restreindre son utilisation.
+- **Alpha software** : Early development stage. May contain changing or unstable features, bugs, and security vulnerability.
+- **Not totally free package** : The YunoHost package of this app is under an overall free licence, but with clauses that restrict its use.
 
 ## Documentations et ressources
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,8 +25,7 @@ La documentation de ce paquet YunoHost [est lisible ici](./doc/DOCS_fr.md) et l'
 
 Veuillez noter que ce paquet utilise la ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), veuillez la lire et l'accepter avant de procéder à l'installation.
 
-
-**Version incluse :** 0.14.0~ynh1
+**Version incluse :** 0.14.1~ynh1
 
 ## Captures d’écran
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "GoToSocial"
 description.en = "Fast ActivityPub social network server written in Go"
 description.fr = "Serveur de réseau social véloce basé sur ActivityPub écrit en Go"
 
-version = "0.14.0~ynh1"
+version = "0.14.1~ynh1"
 
 maintainers = ["OniriCorpe"]
 
@@ -78,16 +78,16 @@ default = true
 [resources]
 [resources.sources.main]
 in_subdir = false
-i386.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.0/gotosocial_0.14.0_linux_386.tar.gz"
-i386.sha256 = "b716a5b4dae751e45516f5de015ac5b476dd1a1ba0ab0ce37268b3af5b89ac63"
-amd64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.0/gotosocial_0.14.0_linux_amd64.tar.gz"
-amd64.sha256 = "9ecdc804f80f4c64d5b024346d25f21b9039632b2a43fe542f99d330c440da19"
-armv6.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.0/gotosocial_0.14.0_linux_armv6.tar.gz"
-armv6.sha256 = "138e25d983af84f853b0c42dd8f1934c6cb838769e22b2c385115d0f87925285"
-armv7.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.0/gotosocial_0.14.0_linux_armv7.tar.gz"
-armv7.sha256 = "11e95c9a8b6b24b33ed42e114f54e57f463924e9ca0f6a05297fe9baeea61746"
-arm64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.0/gotosocial_0.14.0_linux_arm64.tar.gz"
-arm64.sha256 = "aaac998a543484d030d4ea46dc104f9ff3efe11252ff0e7d50a48143368ef4cd"
+i386.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.1/gotosocial_0.14.1_linux_386.tar.gz"
+i386.sha256 = "3f34a6998a0e4fe3a2fb1d5b35f3220cd8cc8d5279622fb1ebdb1f20469b0383"
+amd64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.1/gotosocial_0.14.1_linux_amd64.tar.gz"
+amd64.sha256 = "1a0294f2d613bacc7a03fae9dc125662b9bd939ed63b0cf49cd3260b61850b56"
+armv6.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.1/gotosocial_0.14.1_linux_armv6.tar.gz"
+armv6.sha256 = "02e5d24d94e87e3d5ea21da59d81a123a54fb09b86aa6d40bdd6bb0eb287b704"
+armv7.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.1/gotosocial_0.14.1_linux_armv7.tar.gz"
+armv7.sha256 = "62484f1dda6f8bdb33551c31d07d83e91c82f194cfc812f821440ae371ba42f9"
+arm64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.14.1/gotosocial_0.14.1_linux_arm64.tar.gz"
+arm64.sha256 = "5f23b0c5a0e7d2ca75b674b5f080555f339d9b31af9179605ee7612593fda660"
 
 autoupdate.asset.i386 = "gotosocial_.*linux_386.tar.gz$"
 autoupdate.asset.amd64 = "gotosocial_.*linux_amd64.tar.gz$"

--- a/scripts/restore
+++ b/scripts/restore
@@ -70,7 +70,7 @@ then
 	ynh_script_progression --message="Migrating binary architecture..."
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir"  --keep="config.yaml"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config.yaml"
 fi
 
 # FIXME: this should be managed by the core in the future

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -292,7 +292,7 @@ then
 	architecture=$(detect_arch)
 	
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir"  --keep="config.yaml"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config.yaml"
 fi
 
 # FIXME: this should be managed by the core in the future


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```