### PR TITLE
Rename admin doc to just ADMIN.md + avoid relative links from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # GoToSocial for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/gotosocial.svg)](https://dash.yunohost.org/appci/app/gotosocial) ![Working status](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
+[![Integration level](https://dash.yunohost.org/integration/gotosocial.svg)](https://ci-apps.yunohost.org/ci/apps/gotosocial/) ![Working status](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
 
 [![Install GoToSocial with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 
@@ -21,7 +21,8 @@ GoToSocial is a fast [ActivityPub](https://activitypub.rocks/) social network se
 With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles. All without being tracked or advertised to!
 
 The official documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).  
-The documentation for this YunoHost package [can be read here](./doc/DOCS.md) and the admin is **strongly encouraged to read it**!
+
+Admins are **strongly encouraged to read the documentation** of this package after installing it. It is available in the webadmin under Applications > gotosocial (at the bottom) or [here on the package's repository](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN.md)!
 
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,7 @@ No se debe editar a mano.
 
 # GoToSocial para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/gotosocial.svg)](https://dash.yunohost.org/appci/app/gotosocial) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/gotosocial.svg)](https://ci-apps.yunohost.org/ci/apps/gotosocial/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
 
 [![Instalar GoToSocial con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 
@@ -21,7 +21,8 @@ GoToSocial is a fast [ActivityPub](https://activitypub.rocks/) social network se
 With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles. All without being tracked or advertised to!
 
 The official documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).  
-The documentation for this YunoHost package [can be read here](./doc/DOCS.md) and the admin is **strongly encouraged to read it**!
+
+Admins are **strongly encouraged to read the documentation** of this package after installing it. It is available in the webadmin under Applications > gotosocial (at the bottom) or [here on the package's repository](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN.md)!
 
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,7 @@ EZ editatu eskuz.
 
 # GoToSocial YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/gotosocial.svg)](https://dash.yunohost.org/appci/app/gotosocial) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
+[![Integrazio maila](https://dash.yunohost.org/integration/gotosocial.svg)](https://ci-apps.yunohost.org/ci/apps/gotosocial/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
 
 [![Instalatu GoToSocial YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 
@@ -21,7 +21,8 @@ GoToSocial is a fast [ActivityPub](https://activitypub.rocks/) social network se
 With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles. All without being tracked or advertised to!
 
 The official documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).  
-The documentation for this YunoHost package [can be read here](./doc/DOCS.md) and the admin is **strongly encouraged to read it**!
+
+Admins are **strongly encouraged to read the documentation** of this package after installing it. It is available in the webadmin under Applications > gotosocial (at the bottom) or [here on the package's repository](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN.md)!
 
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,7 @@ Il NE doit PAS être modifié à la main.
 
 # GoToSocial pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/gotosocial.svg)](https://dash.yunohost.org/appci/app/gotosocial) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
+[![Niveau d’intégration](https://dash.yunohost.org/integration/gotosocial.svg)](https://ci-apps.yunohost.org/ci/apps/gotosocial/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
 
 [![Installer GoToSocial avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 
@@ -21,7 +21,8 @@ Un serveur de réseau social véloce basé sur [ActivityPub](https://activitypub
 Avec GoToSocial, vous pouvez rester en contact avec vos amis, publier, lire et partager des images et des articles. Tout cela sans être pisté ni subir de publicité !
 
 Vous pouvez consulter la documentation officielle à l'adresse : [docs.gotosocial.org](https://docs.gotosocial.org).  
-La documentation de ce paquet YunoHost [est lisible ici](./doc/DOCS_fr.md) et l'admin est **vivement encouragé-e à la lire** !
+
+Les admins sont **vivement encouragé-e-s à lire la documentation** de ce paquet après l'avoir installé. Elle est disponible dans la webadmin dans Applications > gotosocial (en bas) ou bien [ici sur le dépôt du paquet](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN_fr.md) !
 
 Veuillez noter que ce paquet utilise la ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), veuillez la lire et l'accepter avant de procéder à l'installation.
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,7 @@ NON debe editarse manualmente.
 
 # GoToSocial para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/gotosocial.svg)](https://dash.yunohost.org/appci/app/gotosocial) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/gotosocial.svg)](https://ci-apps.yunohost.org/ci/apps/gotosocial/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
 
 [![Instalar GoToSocial con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 
@@ -21,7 +21,8 @@ GoToSocial is a fast [ActivityPub](https://activitypub.rocks/) social network se
 With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles. All without being tracked or advertised to!
 
 The official documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).  
-The documentation for this YunoHost package [can be read here](./doc/DOCS.md) and the admin is **strongly encouraged to read it**!
+
+Admins are **strongly encouraged to read the documentation** of this package after installing it. It is available in the webadmin under Applications > gotosocial (at the bottom) or [here on the package's repository](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN.md)!
 
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,7 @@
 
 # YunoHost 上的 GoToSocial
 
-[![集成程度](https://dash.yunohost.org/integration/gotosocial.svg)](https://dash.yunohost.org/appci/app/gotosocial) ![工作状态](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
+[![集成程度](https://dash.yunohost.org/integration/gotosocial.svg)](https://ci-apps.yunohost.org/ci/apps/gotosocial/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/gotosocial.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/gotosocial.maintain.svg)
 
 [![使用 YunoHost 安装 GoToSocial](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gotosocial)
 
@@ -21,7 +21,8 @@ GoToSocial is a fast [ActivityPub](https://activitypub.rocks/) social network se
 With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles. All without being tracked or advertised to!
 
 The official documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).  
-The documentation for this YunoHost package [can be read here](./doc/DOCS.md) and the admin is **strongly encouraged to read it**!
+
+Admins are **strongly encouraged to read the documentation** of this package after installing it. It is available in the webadmin under Applications > gotosocial (at the bottom) or [here on the package's repository](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN.md)!
 
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,7 +1,3 @@
-# Docs of the GoToSocial's package for YunoHost
-
-*[Lire cette documentation en français.](./DOCS_fr.md)*
-
 ## Administration
 
 You can login with your admin user (the one automatically created during installation) to your-instance.com/**admin** to administrate your GoToSocial instance.  

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,7 +1,3 @@
-# Documentation du package GoToSocial pour YunoHost
-
-*[Read this docs in english.](./DOCS.md)*
-
 ## Administration
 
 Vous pouvez vous connecter avec votre utilisateur admin (celui créé automatiquement lors de l'installation) à l'interface d'administration à l'adresse votre-instance.com/**admin** pour administrer votre insance GoToSocial.  

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -3,6 +3,7 @@ GoToSocial is a fast [ActivityPub](https://activitypub.rocks/) social network se
 With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles. All without being tracked or advertised to!
 
 The official documentation is at [docs.gotosocial.org](https://docs.gotosocial.org).  
-The documentation for this YunoHost package [can be read here](./doc/DOCS.md) and the admin is **strongly encouraged to read it**!
+
+Admins are **strongly encouraged to read the documentation** of this package after installing it. It is available in the webadmin under Applications > gotosocial (at the bottom) or [here on the package's repository](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN.md)!
 
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -3,6 +3,7 @@ Un serveur de réseau social véloce basé sur [ActivityPub](https://activitypub
 Avec GoToSocial, vous pouvez rester en contact avec vos amis, publier, lire et partager des images et des articles. Tout cela sans être pisté ni subir de publicité !
 
 Vous pouvez consulter la documentation officielle à l'adresse : [docs.gotosocial.org](https://docs.gotosocial.org).  
-La documentation de ce paquet YunoHost [est lisible ici](./doc/DOCS_fr.md) et l'admin est **vivement encouragé-e à la lire** !
+
+Les admins sont **vivement encouragé-e-s à lire la documentation** de ce paquet après l'avoir installé. Elle est disponible dans la webadmin dans Applications > gotosocial (en bas) ou bien [ici sur le dépôt du paquet](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/doc/ADMIN_fr.md) !
 
 Veuillez noter que ce paquet utilise la ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), veuillez la lire et l'accepter avant de procéder à l'installation.


### PR DESCRIPTION
Followup of https://github.com/YunoHost/issues/issues/2347

- I'm not sure to understand why the page is named DOCS.md instead of the regular ADMIN.md (though any FOOBAR.md is supported, but it was more intended for "specific topics" to not overwhel the regular ADMIN.md)
- Remove link to other language because the webadmin will display the appropriate language right away
- Rework the pointed to the admin doc in the description to avoid relative link and point the fact that the doc is available in the webadmin which should be the primary mean to read it (in an ideal world we don't want to send people to github because it spooks people)
