### PR TITLE
modified PreUpgrade information (English) to reflect the silent upgra…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Shipped version:** 0.18.0~ynh1
+**Shipped version:** 0.18.1~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Versión actual:** 0.18.0~ynh1
+**Versión actual:** 0.18.1~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Paketatutako bertsioa:** 0.18.0~ynh1
+**Paketatutako bertsioa:** 0.18.1~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -29,7 +29,7 @@ Les admins sont **vivement encouragé-e-s à lire la documentation** de ce paque
 Veuillez noter que ce paquet utilise la ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), veuillez la lire et l'accepter avant de procéder à l'installation.
 
 
-**Version incluse :** 0.18.0~ynh1
+**Version incluse :** 0.18.1~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Versión proporcionada:** 0.18.0~ynh1
+**Versión proporcionada:** 0.18.1~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Versi terkirim:** 0.18.0~ynh1
+**Versi terkirim:** 0.18.1~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Geleverde versie:** 0.18.0~ynh1
+**Geleverde versie:** 0.18.1~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Dostarczona wersja:** 0.18.0~ynh1
+**Dostarczona wersja:** 0.18.1~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**Поставляемая версия:** 0.18.0~ynh1
+**Поставляемая версия:** 0.18.1~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -29,7 +29,7 @@ Admins are **strongly encouraged to read the documentation** of this package aft
 Please note that this package uses the ["i'm so tired" software license 1.0](https://github.com/YunoHost-Apps/gotosocial_ynh/blob/master/LICENSE), please read it and accept it before proceeding with installation.
 
 
-**分发版本：** 0.18.0~ynh1
+**分发版本：** 0.18.1~ynh1
 
 ## 截图
 

--- a/doc/PRE_UPGRADE.md
+++ b/doc/PRE_UPGRADE.md
@@ -1,3 +1,2 @@
-GoToSocial takes some time (from some seconds to some hours) after each version upgrades to perform various things, like database migration or optimizations. 
-This takes place silently without any progress information after the yunohost upgrade process.
+GoToSocial takes some time (from some seconds to some hours) after each version upgrades to perform various things, like database migration or optimizations.  
 If your instance is not accessible, please be patient and **do not** restart it or the complete server manually at the risk of breaking everything!

--- a/doc/PRE_UPGRADE.md
+++ b/doc/PRE_UPGRADE.md
@@ -1,2 +1,3 @@
-GoToSocial takes some time (from some seconds to some minutes) after each version upgrades to perform various things, like database migration or optimizations.  
-If your instance is not accessible, please be patient and **do not** restart it manually at the risk of breaking everything!
+GoToSocial takes some time (from some seconds to some hours) after each version upgrades to perform various things, like database migration or optimizations. 
+This takes place silently without any progress information after the yunohost upgrade process.
+If your instance is not accessible, please be patient and **do not** restart it or the complete server manually at the risk of breaking everything!

--- a/doc/PRE_UPGRADE.md
+++ b/doc/PRE_UPGRADE.md
@@ -1,2 +1,2 @@
 GoToSocial takes some time (from some seconds to some hours) after each version upgrades to perform various things, like database migration or optimizations.  
-If your instance is not accessible, please be patient and **do not** restart it or the complete server manually at the risk of breaking everything!
+If your instance is not accessible, please be patient and **do not** restart it manually at the risk of breaking everything!  

--- a/doc/PRE_UPGRADE_fr.md
+++ b/doc/PRE_UPGRADE_fr.md
@@ -1,2 +1,2 @@
-GoToSocial prend un certain temps (de quelques secondes à plusieurs minutes) après chaque mise à jour afin de réaliser diverses choses, telles que les migrations ou des mises à jour dans la base de donnée.  
+GoToSocial prend un certain temps (de quelques secondes à plusieurs heures) après chaque mise à jour afin de réaliser diverses choses, telles que les migrations ou des mises à jour dans la base de donnée.  
 Si votre instance est inaccessible, s'il vous plaît, faites preuve de patience et **ne le redémarrez pas** au risque de tout casser !

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,7 +9,7 @@ description.gl = "Un servidor áxil para a rede social ActivityPub"
 description.ca = "Un servidor de xarxa social basat en ActivityPub"
 description.fr = "Serveur de réseau social véloce basé sur ActivityPub"
 
-version = "0.18.0~ynh1"
+version = "0.18.1~ynh1"
 
 maintainers = [ "OniriCorpe" ]
 
@@ -91,14 +91,14 @@ default = true
 [resources.sources.main]
 in_subdir = false
 
-i386.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.0/gotosocial_0.18.0_linux_386_nowasm.tar.gz"
-i386.sha256 = "6076c493ded9c67136f4f782f8edafdaa6d10828f926e5bd7e0bc16dea42f490"
-amd64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.0/gotosocial_0.18.0_linux_amd64.tar.gz"
-amd64.sha256 = "37781daae56b4964912adbde21c6988e823fb9deb3c525669e2252ab77810c9c"
-arm64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.0/gotosocial_0.18.0_linux_arm64.tar.gz"
-arm64.sha256 = "68eb9d9429e1b9e164d0aca2488b095b185d126acc60fec407a04b113ee56713"
-armhf.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.0/gotosocial_0.18.0_linux_armv7_nowasm.tar.gz"
-armhf.sha256 = "7402963144e90cb51cb02c6b85216e35d4a7255d9b293a2fb069d90405094b35"
+i386.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.1/gotosocial_0.18.1_linux_386_nowasm.tar.gz"
+i386.sha256 = "d6f56e6999c78e001aa98f4e61c6b844a3633bfe9d781c6a187d1873f9e9b88e"
+amd64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.1/gotosocial_0.18.1_linux_amd64.tar.gz"
+amd64.sha256 = "b325075b9b22ebb74766f22cd29d49304fa476425e2e113f91bcb64edc887daa"
+arm64.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.1/gotosocial_0.18.1_linux_arm64.tar.gz"
+arm64.sha256 = "7874a4a41d97aee65103a37883bd6a929d99289bf3bca3890ca8a815f34ad4dd"
+armhf.url = "https://github.com/superseriousbusiness/gotosocial/releases/download/v0.18.1/gotosocial_0.18.1_linux_armv7_nowasm.tar.gz"
+armhf.sha256 = "ffdb01fc8d15b6e6ef559c4a3d16e6b0eea388294171fbd78766f03a31cde95d"
 
 autoupdate.asset.i386 = "gotosocial_.*_linux_386_nowasm.tar.gz$"
 autoupdate.asset.amd64 = "gotosocial_.*_linux_amd64.tar.gz$"


### PR DESCRIPTION
Enhanced PreUpgrade text to avoid misunderstanding (like it happend to me :) )

## Problem

- to better emphasis the silent internal GoToSocial upgrade process to avoid yunohost users to restart gts or their servers too soon because of up to 2 hours of non-responding GTS instance

## Solution
Enrich the PreUpgrade  text (English only, my French got stale)

## PR Status
- [x] The fix/enhancement were manually tested (if applicable)


